### PR TITLE
プログラムの効率化（cloneの削減など）

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ fn transform_record(record: &FirehoseRecord) -> TransformationRecord {
         .unwrap_or_else(|_|
             TransformationRecord {
                 record_id: record.record_id.to_string(),
-                data: record.data.clone(),
+                data: record.data.to_string(),
                 result: NG,
             }
         )
@@ -188,7 +188,7 @@ struct FirehoseEvent {
     invocation_id: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 struct FirehoseRecord {
     #[serde(rename = "recordId")]
     record_id: String,


### PR DESCRIPTION
ブログ記事を拝見しました。いいですね！ たしかにRustは大量のデータを変換するような用途に向いていると思います。

主にデータのコピー（`clone()`など）に関する部分で効率化できるところがあったので、修正してみました。

テストデータがないので、`cargo check`が通ることだけを確認しており、実際に走らせてはいません。どのくらい高速化するかはわからないのですが、一度、試してもらえると嬉しいです。（20%くらいは速くなるのではと期待してます）

変更点
- `Result`の`or()`と`unwrap_or()`を`or_else()`、`unwrap_or_else()`に変更しました。
  - `or()`と`unwrap_or()`は`Result`が`Ok`か`Err`かに関係なく引数の式を必ず評価するので、今回のように`DateTime::parse_from_str()`や`record.data.clone()`が含まれていると、`Ok`のときに無駄な仕事をしてしまいます。
  - そこでこれらを`or_else()`、`unwrap_or_else()`に変更し引数としてクロージャを渡すことで、`Err`の時のみ`parse_from_str()`や`record.data.clone()`が実行されるようにしました。
- できる限り`String`のコピーを回避しました。
  - たとえば`AccessLog`のいくつかの`String`型のフィールドを`&str`に変更することで、`to_owned()`を削減しました。
- `xs[6].parse::<u32>()?`という式が2つあり、1つ目の式の結果は使われていなかったので、1つ目の式を削除しました。
- `event.record_slice().par_iter()`（`record_slice()`は`as_slice()`を呼ぶ）はより単純な`event.records.par_iter()`で動くので、そちらに変更しました。（性能への目に見える影響なさそうですが）

あとは、プロセッサ数が1ということでしたら、Rayonは使わない方がいいかもしれません。ワーカースレッド用のタスクを切り出すオーバーヘッドがなくなり、速くなるかもしれません。